### PR TITLE
Lany connection ingredient group

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -242,12 +242,12 @@ public class GroupController {
         }
 
         // retrieve all ingretients available from the members of the group
-        Set<Ingredient> groupIngredients = new HashSet<>();
-        for(Long memberId : memberIds) {
-            User user = userService.getUserById(memberId);
-            Set<Ingredient> userIngredients = user.getIngredients();
-            groupIngredients.addAll(userIngredients);
-        }
+        Set<Ingredient> groupIngredients = group.getIngredients(); // retrieve directly from group now
+        // for(Long memberId : memberIds) {
+        //     User user = userService.getUserById(memberId);
+        //     Set<Ingredient> userIngredients = user.getIngredients();
+        //     groupIngredients.addAll(userIngredients);
+        // }
 
         // convert to API representation
         List<IngredientGetDTO> ingredientGetDTOs = new ArrayList<>();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -242,12 +242,7 @@ public class GroupController {
         }
 
         // retrieve all ingretients available from the members of the group
-        Set<Ingredient> groupIngredients = group.getIngredients(); // retrieve directly from group now
-        // for(Long memberId : memberIds) {
-        //     User user = userService.getUserById(memberId);
-        //     Set<Ingredient> userIngredients = user.getIngredients();
-        //     groupIngredients.addAll(userIngredients);
-        // }
+        Set<Ingredient> groupIngredients = group.getIngredients();
 
         // convert to API representation
         List<IngredientGetDTO> ingredientGetDTOs = new ArrayList<>();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -20,10 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
-
-
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
@@ -200,7 +200,7 @@ public class UserController {
     public void updateUserIngredients(@PathVariable Long userId,
                                       @RequestBody List<IngredientPutDTO> ingredientsPutDTO, // I get list of objects (arrays)
                                       @RequestHeader(name = "X-Token") String xToken) {
-        User user = userService.getUserById(userId);
+        userService.getUserById(userId);
 
         Long tokenId = userService.getUseridByToken(xToken);
         if (!tokenId.equals(userId)) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs23.constant.VotingType;
 import java.io.Serializable;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -35,9 +36,13 @@ public class Group implements Serializable {
     @ElementCollection
     private Set<Long> guestIds;
 
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    private Set<Ingredient> ingredientsSet;
+
     // constructor
     public Group() {
         this.guestIds = new HashSet<>();
+        this.ingredientsSet = new HashSet<>();
     }
 
     public Long getId() {
@@ -90,6 +95,18 @@ public class Group implements Serializable {
 
     public void removeGuestId(Long guestId) {
         this.guestIds.remove(guestId);
+    }
+
+    public void addIngredient(List<Ingredient> ingredients) {
+        for (Ingredient ingredient : ingredients) {
+            if (!ingredientsSet.contains(ingredient)) {
+                ingredientsSet.add(ingredient);
+            }
+        }
+    }
+
+    public Set<Ingredient> getIngredients() {
+        return ingredientsSet;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Ingredient.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Ingredient.java
@@ -20,13 +20,18 @@ public class Ingredient implements Serializable  {
     private Long calculatedRating;
 
     @ManyToMany(mappedBy = "ingredientsSet")
-    private Set<User> usersSet = new HashSet<>();
+    private Set<User> usersSet;
+
+    @ManyToOne
+    private Group group;
 
     public Ingredient() {
-        // default constructor needed
+        this.usersSet = new HashSet<>();
     }
+
     public Ingredient(String name) {
         this.name = name;
+        this.usersSet = new HashSet<>();
     }
 
     //Methods
@@ -61,4 +66,13 @@ public class Ingredient implements Serializable  {
     public void setUsersSet(Set<User> usersSet) {
         this.usersSet = usersSet;
     }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/IngredientRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/IngredientRepository.java
@@ -1,12 +1,8 @@
 package ch.uzh.ifi.hase.soprafs23.repository;
 
-import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
-import ch.uzh.ifi.hase.soprafs23.entity.Invitation;
-import ch.uzh.ifi.hase.soprafs23.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.persistence.criteria.CriteriaBuilder;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/IngredientGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/IngredientGetDTO.java
@@ -4,7 +4,6 @@ public class IngredientGetDTO {
 
     private Long id;
     private String name;
-    private Long calculatedRating;
 
     public Long getId() {
         return id;
@@ -20,14 +19,6 @@ public class IngredientGetDTO {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Long getCalculatedRating() {
-        return calculatedRating;
-    }
-
-    public void setCalculatedRating(Long calculatedRating) {
-        this.calculatedRating = calculatedRating;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/mapper/DTOMapper.java
@@ -51,7 +51,6 @@ public interface DTOMapper {
 
     @Mapping(source = "id", target = "id")
     @Mapping(source = "name", target = "name")
-    @Mapping(source = "calculatedRating", target = "calculatedRating")
     IngredientGetDTO convertEntityToIngredientGetDTO(Ingredient ingredient);
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -729,15 +729,16 @@ public class GroupControllerTest {
     }
 
     @Test
-    public void testGetIngredientsOfGroupById_valid_onlyHost() throws Exception {
+    public void testGetIngredientsOfGroupById_valid_oneIngredient() throws Exception {
         // given
         Ingredient apple = new Ingredient();
         apple.setId(19L);
         apple.setName("apple");
+        apple.setCalculatedRating(1L);
 
         List<Ingredient> ingredients = new ArrayList<>();
         ingredients.add(apple);
-        user.addIngredient(ingredients);
+        group.addIngredient(ingredients);
 
         List<Long> memberIds = new ArrayList<>();
         memberIds.add(group.getHostId());
@@ -755,35 +756,28 @@ public class GroupControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)))
             .andExpect(jsonPath("$[0].id", is(apple.getId().intValue())))
-            .andExpect(jsonPath("$[0].name", is(apple.getName())));
+            .andExpect(jsonPath("$[0].name", is(apple.getName())))
+            .andExpect(jsonPath("$[0].calculatedRating", is(apple.getCalculatedRating().intValue())));
     }
 
     @Test
-    public void testGetIngredientsOfGroupById_valid_hostAndGuest() throws Exception {
+    public void testGetIngredientsOfGroupById_valid_multipleIngredients() throws Exception {
         // given
-        Ingredient apple = new Ingredient();
-        apple.setId(13L);
-        apple.setName("apple");
-        List<Ingredient> hostIngredients = new ArrayList<>();
-        hostIngredients.add(apple);
-        user.addIngredient(hostIngredients);
+        Ingredient apple = new Ingredient("apple");
+        Ingredient pear = new Ingredient("pear");
+        Ingredient banana = new Ingredient("banana");
 
-        User guest = new User();
-        guest.setId(15L);
-        Ingredient pear = new Ingredient();
-        pear.setId(19L);
-        pear.setName("pear");
-        List<Ingredient> guestIngredients = new ArrayList<>();
-        guestIngredients.add(pear);
-        user.addIngredient(guestIngredients);
+        List<Ingredient> ingredients = new ArrayList<>();
+        ingredients.add(apple);
+        ingredients.add(pear);
+        ingredients.add(banana);
+        group.addIngredient(ingredients);
 
         List<Long> memberIds = new ArrayList<>();
         memberIds.add(group.getHostId());
-        memberIds.add(guest.getId());
 
         // mocks
         given(groupService.getAllMemberIdsOfGroup(group)).willReturn(memberIds);
-        given(userService.getUserById(guest.getId())).willReturn(guest);
 
         // when
         MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/ingredients", group.getId())
@@ -793,7 +787,7 @@ public class GroupControllerTest {
         // then
         mockMvc.perform(getRequest)
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", hasSize(2)));
+            .andExpect(jsonPath("$", hasSize(3)));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -756,8 +756,7 @@ public class GroupControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)))
             .andExpect(jsonPath("$[0].id", is(apple.getId().intValue())))
-            .andExpect(jsonPath("$[0].name", is(apple.getName())))
-            .andExpect(jsonPath("$[0].calculatedRating", is(apple.getCalculatedRating().intValue())));
+            .andExpect(jsonPath("$[0].name", is(apple.getName())));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs23.service;
 
 import ch.uzh.ifi.hase.soprafs23.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
+import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
 import ch.uzh.ifi.hase.soprafs23.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs23.repository.IngredientRepository;
@@ -26,10 +27,14 @@ public class UserServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private GroupService groupService;
+
+    @Mock
     private IngredientRepository ingredientRepository;
 
     @InjectMocks
     private UserService userService;
+
     private UserPutDTO userPutDTO;
 
     private IngredientPutDTO ingredientPutDTO;
@@ -234,6 +239,10 @@ public class UserServiceTest {
 
     @Test
     void addUserIngredients_withExistingUserIdAndNewIngredient_addsIngredientToUser() {
+        // user needs to be in a group
+        user.setGroupId(5L);
+        when(groupService.getGroupById(user.getGroupId())).thenReturn(new Group());
+
         Long userId = user.getId();
         IngredientPutDTO ingredientPutDTO = new IngredientPutDTO();
         ingredientPutDTO.setName("new_ingredient_name");
@@ -250,6 +259,10 @@ public class UserServiceTest {
 
     @Test
     void addUserIngredients_withExistingIngredients_doesNotAddDuplicatesToUser() {
+        // user needs to be in a group
+        user.setGroupId(5L);
+        when(groupService.getGroupById(user.getGroupId())).thenReturn(new Group());
+
         Long userId = user.getId();
 
         Ingredient existingIngredient = user.getIngredients().iterator().next();


### PR DESCRIPTION
I closed the pull request with only the addition of the GET request to get the ingredients of a group.
I merged that branch onto this branch where I connected group and ingredient. so this new pull request has the following additions:
- entities Group and Ingredient are connected (Group has `Set <Ingredient> ingredientsSet` and Ingredient has `Group group`).
- adapted the PUT /users/{userId}/ingredients call and tests accordingly (most changes in UserService method addUserIngredients)
- GET /groups/{groupId}/ingredients mapping (mostly as it was in the previous PR, but adapted the call in GroupController and the tests accordingly, but all will appear new here as it was never merged to development) 