### PR TITLE
call to get guests of a groop + tests

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -240,12 +240,10 @@ public class GroupController {
         // get the guests of the group
         List<Long> guestIds = groupService.getAllGuestIdsOfGroup(group);
 
-        // 204 - no open invitations
+        // 204 - no guests in group
         if(guestIds.size() == 0) {
             throw new ResponseStatusException(HttpStatus.NO_CONTENT);
         }
-
-        
 
         // convert each user to the API representation
         List<UserGetDTO> userGetDTOs = new ArrayList<>();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -239,9 +239,16 @@ public class GroupController {
 
         // get the guests of the group
         List<Long> guestIds = groupService.getAllGuestIdsOfGroup(group);
-        List<UserGetDTO> userGetDTOs = new ArrayList<>();
+
+        // 204 - no open invitations
+        if(guestIds.size() == 0) {
+            throw new ResponseStatusException(HttpStatus.NO_CONTENT);
+        }
+
+        
 
         // convert each user to the API representation
+        List<UserGetDTO> userGetDTOs = new ArrayList<>();
         for (Long userId : guestIds) {
             User user = userService.getUserById(userId);
             userGetDTOs.add(DTOMapper.INSTANCE.convertEntityToUserGetDTO(user));

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -224,6 +224,32 @@ public class GroupController {
         return userGetDTOs;
     }
     
+    @GetMapping("/groups/{groupId}/guests")
+    @ResponseStatus(HttpStatus.OK) // 200
+    @ResponseBody
+    public List<UserGetDTO> getGroupGuestsById(@PathVariable Long groupId, HttpServletRequest request) {
+        // 404 - group not found
+        Group group = groupService.getGroupById(groupId);
+
+        // 401 - not authorized
+        Long tokenId = userService.getUseridByToken(request.getHeader("X-Token"));
+        if(tokenId.equals(0L)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, String.format("You are not authorized."));
+        }
+
+        // get the guests of the group
+        List<Long> guestIds = groupService.getAllGuestIdsOfGroup(group);
+        List<UserGetDTO> userGetDTOs = new ArrayList<>();
+
+        // convert each user to the API representation
+        for (Long userId : guestIds) {
+            User user = userService.getUserById(userId);
+            userGetDTOs.add(DTOMapper.INSTANCE.convertEntityToUserGetDTO(user));
+        }
+
+        return userGetDTOs;
+    }
+
     @GetMapping("/groups/{groupId}/ingredients")
     @ResponseStatus(HttpStatus.OK) // 200
     @ResponseBody

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -82,11 +82,18 @@ public class GroupService {
         List<Long> memberIds = new ArrayList<>();
 
         memberIds.add(group.getHostId());
-
-        for(Long guestId : group.getGuestIds()) {
-            memberIds.add(guestId);
-        }
+        memberIds.addAll(getAllGuestIdsOfGroup(group));
 
         return memberIds;
+    }
+
+    public List<Long> getAllGuestIdsOfGroup(Group group) {
+        List<Long> guestIds = new ArrayList<>();
+
+        for(Long guestId : group.getGuestIds()) {
+            guestIds.add(guestId);
+        }
+
+        return guestIds;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -861,6 +861,28 @@ public class GroupControllerTest {
     }
 
     @Test
+    public void testGetGroupGuestsById_noGuestsInGroup() throws Exception {
+         // mocks
+        given(groupService.getGroupById(group.getId())).willReturn(group);
+        given(groupService.getAllGuestIdsOfGroup(group)).willReturn(new ArrayList<>());
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/guests", group.getId())
+                                                    .contentType(MediaType.APPLICATION_JSON)
+                                                    .header("X-Token", user.getToken());
+
+        // then
+        mockMvc.perform(getRequest)
+            .andExpect(status().isNoContent());
+          
+        // verifies
+        verify(groupService, times(1)).getGroupById(group.getId());
+        verify(userService, times(1)).getUseridByToken(user.getToken());
+        verify(groupService, times(1)).getAllGuestIdsOfGroup(group);
+        verify(userService, times(0)).getUserById(any());
+    }
+
+    @Test
     public void testGetGroupGuestsById_groupNotFound() throws Exception {
         Long anotherGroupId = 8L;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/service/GroupServiceTest.java
@@ -88,6 +88,22 @@ public class GroupServiceTest {
         expectedMembers.add(secondGuestId);
         assertEquals(expectedMembers, groupService.getAllMemberIdsOfGroup(group));
     }
+
+    @Test
+    public void getAllGuestIdsOfGroup_test() {
+        List<Long> expectedMembers = new ArrayList<>();
+        assertEquals(expectedMembers, groupService.getAllGuestIdsOfGroup(group));
+
+        Long firstGuestId = 4L;
+        group.addGuestId(firstGuestId);
+        expectedMembers.add(firstGuestId);
+        assertEquals(expectedMembers, groupService.getAllGuestIdsOfGroup(group));
+
+        Long secondGuestId = 7L;
+        group.addGuestId(secondGuestId);
+        expectedMembers.add(secondGuestId);
+        assertEquals(expectedMembers, groupService.getAllGuestIdsOfGroup(group));
+    }
     
     @Test
     public void createGroup_success() {


### PR DESCRIPTION
GET groups/{groupId}/guests call implemented + tested

works exactly the same as GET groups/{groupId}/members, but without the host