### PR TITLE
Fix: 500 error when GET /ingredients with weird initialString

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import java.nio.charset.StandardCharsets;
@@ -71,14 +72,15 @@ public class APIService {
             }
 
             if (ingredientNames.isEmpty()) {
-                throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "There is no ingredient starting with those letters"); // 404 - error
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "There is no ingredient starting with those letters"); // 404 - error
             }
 
             return ingredientNames;
         } catch (HttpServerErrorException e) {
-            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "You are not authorized.");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized.");
         }
     }
+    
     public String getApiKey() {
         return apiKey;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
@@ -34,7 +34,7 @@ public class APIService {
             List<Recipe> recipes = Objects.requireNonNull(searchResponse.getBody()).getResults();
 
             if (recipes.isEmpty()) {
-                throw new HttpClientErrorException(HttpStatus.CONFLICT, "Results cannot be calculated yet");
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Results cannot be calculated yet");
             }
 
             Random random = new Random();
@@ -47,12 +47,12 @@ public class APIService {
             return detailedRecipe;
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-                throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "Group not found");
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found");
             } else {
                 throw e;
             }
         } catch (HttpServerErrorException e) {
-            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "Not authorized");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authorized");
         }
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
@@ -141,7 +141,7 @@ public class APIControllerTest {
                 "&intolerances=" + intolerances + "&diet=" + diet + "&cuisine=" + cuisine;
 
         when(restTemplate.getForEntity(searchApiUrl, ComplexSearchResponse.class))
-                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Not found"));
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Not found"));
 
         // Act
         try {
@@ -206,7 +206,7 @@ public class APIControllerTest {
 
         // Set up mocks for the case when the API returns 404 status code
         when(apiService.getListOfIngredients(nonExistentIngredient))
-                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Ingredients not found"));
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredients not found"));
 
         // Perform the test
         try {
@@ -241,3 +241,4 @@ public class APIControllerTest {
     }
 
 }
+    


### PR DESCRIPTION
The trouble with the weird 500 that should have been a 404 was because we were throwing HttpClientErrorException instead of ResponseStatusException!! 

The first commit here is where I fixed this specifically for the 500 that should be a 404 that we talked about, this morning, and in the second commit here I went through everything and changed thrown HttpClientErrorExceptions to ResponseStatusExceptions.

As far as I can tell everything still works, and I'm thinking maybe that's the weird 500s that kallia keeps getting 🤔