### PR TITLE
Orestis get request

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -452,10 +452,6 @@ public class GroupController {
         return userGetDTOs;
     }
 
-
-
-
-
     @PutMapping("/groups/{groupId}/ratings/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateRatings(@PathVariable Long groupId, @PathVariable Long userId,

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -395,7 +395,7 @@ public class GroupController {
         // Check if the user is the host of the group
         Long tokenId = userService.getUseridByToken(request.getHeader("X-Token"));
         if (!tokenId.equals(currentGroup.getHostId())) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authorized");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized");
         }
 
         // Get a list of open join requests

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/JoinRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/JoinRequestRepository.java
@@ -12,4 +12,5 @@ public interface JoinRequestRepository extends JpaRepository<JoinRequest, Long> 
     Optional<JoinRequest> findByGuestIdAndGroupId(Long guestId, Long groupId);
 
     List<JoinRequest> findAllByGuestId(Long guestId);
+    List<JoinRequest> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,6 +80,11 @@ public class JoinRequestService {
             }
         }
     }
+    public List<JoinRequest> getOpenJoinRequestsByGroupId(Long groupId) {
+        return joinRequestRepository.findAllByGroupId(groupId);
+    }
+
+
 }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -7,11 +7,8 @@ import ch.uzh.ifi.hase.soprafs23.entity.Invitation;
 import ch.uzh.ifi.hase.soprafs23.entity.JoinRequest;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
 import ch.uzh.ifi.hase.soprafs23.repository.JoinRequestRepository;
-import ch.uzh.ifi.hase.soprafs23.rest.dto.GroupPostDTO;
-import ch.uzh.ifi.hase.soprafs23.rest.dto.IngredientPutDTO;
-import ch.uzh.ifi.hase.soprafs23.rest.dto.InvitationPutDTO;
-import ch.uzh.ifi.hase.soprafs23.rest.dto.JoinRequestPostDTO;
-import ch.uzh.ifi.hase.soprafs23.rest.dto.JoinRequestPutDTO;
+import ch.uzh.ifi.hase.soprafs23.rest.dto.*;
+import ch.uzh.ifi.hase.soprafs23.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs23.service.GroupService;
 import ch.uzh.ifi.hase.soprafs23.service.InvitationService;
 import ch.uzh.ifi.hase.soprafs23.service.JoinRequestService;
@@ -1429,6 +1426,60 @@ public class GroupControllerTest {
                         .header("X-Token", "invalid-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(joinRequestPutDTO)))
+                .andExpect(status().isUnauthorized());
+    }
+    @Test
+    void getOpenJoinRequests_returns200_whenOpenRequestsPresent() throws Exception {
+        // Arrange
+        JoinRequest joinRequest = new JoinRequest();
+        joinRequest.setGuestId(3L);
+        joinRequest.setGroupId(group.getId());
+
+        List<JoinRequest> joinRequestList = Collections.singletonList(joinRequest);
+        given(joinRequestService.getOpenJoinRequestsByGroupId(group.getId())).willReturn(joinRequestList);
+
+        // Act
+        mockMvc.perform(get("/groups/{groupId}/requests", group.getId())
+                        .header("X-Token", user.getToken()))
+                // Assert
+                .andExpect(status().isOk());
+    }
+    @Test
+    void getOpenJoinRequests_returns204_whenNoOpenRequests() throws Exception {
+        // Arrange
+        given(joinRequestService.getOpenJoinRequestsByGroupId(group.getId())).willReturn(Collections.emptyList());
+
+        // Act
+        mockMvc.perform(get("/groups/{groupId}/requests", group.getId())
+                        .header("X-Token", user.getToken()))
+                // Assert
+                .andExpect(status().isNoContent());
+    }
+    @Test
+    void getOpenJoinRequests_returns404_whenGroupNotFound() throws Exception {
+        // Arrange
+        Long nonExistentGroupId = 99L;
+        given(groupService.getGroupById(nonExistentGroupId)).willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+
+        // Act
+        mockMvc.perform(get("/groups/{groupId}/requests", nonExistentGroupId)
+                        .header("X-Token", user.getToken()))
+                // Assert
+                .andExpect(status().isNotFound());
+    }
+    @Test
+    void getOpenJoinRequests_returns401_whenUserNotHost() throws Exception {
+        // Arrange
+        User nonHostUser = new User();
+        nonHostUser.setId(3L);
+        nonHostUser.setToken("nonhosttoken");
+
+        given(userService.getUseridByToken(nonHostUser.getToken())).willReturn(nonHostUser.getId());
+
+        // Act
+        mockMvc.perform(get("/groups/{groupId}/requests", group.getId())
+                        .header("X-Token", nonHostUser.getToken()))
+                // Assert
                 .andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
This PR is for the GET /groups/{groupId}/requests mapping. Simple code providing a list of all the join requests that are open for the current group based on a List after the JoinRequest objects are converted to UserGetDTOs and are returned.

P.S. You might see that the previous PR failed. That was cause of the merge of the Fix: 500 which was merged and wasn't merged to this branch before pushing. 