### PR TITLE
Orestis state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ springBoot {
 
 dependencies {
     implementation 'org.mapstruct:mapstruct:1.3.1.Final'
+    testImplementation 'junit:junit:4.13.1'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/constant/GroupState.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/constant/GroupState.java
@@ -1,0 +1,8 @@
+package ch.uzh.ifi.hase.soprafs23.constant;
+
+public enum GroupState {
+    GROUPFORMING,
+    INGREDIENTENTERING,
+    INGREDIENTVOTING,
+    FINAL
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -417,10 +417,6 @@ public class GroupController {
         return userGetDTOs;
     }
 
-
-
-
-
     @PutMapping("/groups/{groupId}/ratings/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateRatings(@PathVariable Long groupId, @PathVariable Long userId,
@@ -448,6 +444,7 @@ public class GroupController {
             groupService.calculateRatingPerGroup(groupId);
         }
     }
+
     @PutMapping("/groups/{groupId}/state")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void changeGroupState(@PathVariable Long groupId, @RequestBody GroupState newState, HttpServletRequest request) {
@@ -482,7 +479,5 @@ public class GroupController {
 
         return group.getGroupState();
     }
-
-
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs23.controller;
 
+import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
 import ch.uzh.ifi.hase.soprafs23.constant.VotingType;
 import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
@@ -447,5 +448,41 @@ public class GroupController {
             groupService.calculateRatingPerGroup(groupId);
         }
     }
+    @PutMapping("/groups/{groupId}/state")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeGroupState(@PathVariable Long groupId, @RequestBody GroupState newState, HttpServletRequest request) {
+        Group group = groupService.getGroupById(groupId);
+
+        if (group == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found");
+        }
+
+        Long tokenId = userService.getUseridByToken(request.getHeader("X-Token"));
+        if (!tokenId.equals(group.getHostId())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized");
+        }
+
+        groupService.changeGroupState(groupId, newState);
+    }
+
+    @GetMapping("/groups/{groupId}/state")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public GroupState getGroupState(@PathVariable Long groupId, HttpServletRequest request) {
+        Group group = groupService.getGroupById(groupId);
+
+        if (group == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found");
+        }
+
+        Long tokenId = userService.getUseridByToken(request.getHeader("X-Token"));
+        if (!tokenId.equals(group.getHostId())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized");
+        }
+
+        return group.getGroupState();
+    }
+
+
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs23.entity;
 
 import javax.persistence.*;
 
+import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
 import ch.uzh.ifi.hase.soprafs23.constant.VotingType;
 
 import java.io.Serializable;
@@ -39,10 +40,15 @@ public class Group implements Serializable {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private Set<Ingredient> ingredientsSet;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GroupState state;
+
     // constructor
     public Group() {
         this.guestIds = new HashSet<>();
         this.ingredientsSet = new HashSet<>();
+        this.state = GroupState.GROUPFORMING;
     }
 
     public Long getId() {
@@ -107,6 +113,14 @@ public class Group implements Serializable {
 
     public Set<Ingredient> getIngredients() {
         return ingredientsSet;
+    }
+
+    public GroupState getGroupState() {
+        return state;
+    }
+
+    public void setGroupState(GroupState state) {
+        this.state = state;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/Group.java
@@ -42,13 +42,13 @@ public class Group implements Serializable {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private GroupState state;
+    private GroupState groupState;
 
     // constructor
     public Group() {
         this.guestIds = new HashSet<>();
         this.ingredientsSet = new HashSet<>();
-        this.state = GroupState.GROUPFORMING;
+        this.groupState = GroupState.GROUPFORMING;
     }
 
     public Long getId() {
@@ -116,11 +116,11 @@ public class Group implements Serializable {
     }
 
     public GroupState getGroupState() {
-        return state;
+        return groupState;
     }
 
-    public void setGroupState(GroupState state) {
-        this.state = state;
+    public void setGroupState(GroupState groupState) {
+        this.groupState = groupState;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/InvitationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/InvitationRepository.java
@@ -15,5 +15,6 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     List<Invitation> findByGuestId(Long guestId);
 
     List<Invitation> findByGroupIdAndGuestId(Long groupId, Long guestId);
+    void deleteAllByGroupId(Long groupId);
     
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/JoinRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/JoinRequestRepository.java
@@ -13,4 +13,5 @@ public interface JoinRequestRepository extends JpaRepository<JoinRequest, Long> 
 
     List<JoinRequest> findAllByGuestId(Long guestId);
     List<JoinRequest> findAllByGroupId(Long groupId);
+    void deleteAllByGroupId(Long groupId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/GroupGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/GroupGetDTO.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs23.rest.dto;
 
+import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
+
 public class GroupGetDTO {
     private Long id;
 
@@ -10,6 +12,8 @@ public class GroupGetDTO {
     private String hostName;
 
     private String votingType;
+
+    private GroupState state;
 
     public Long getId() {
         return id;
@@ -51,4 +55,11 @@ public class GroupGetDTO {
         this.votingType = votingType;
     }
 
+    public GroupState getState() {
+        return state;
+    }
+
+    public void setState(GroupState state) {
+        this.state = state;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/GroupGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/rest/dto/GroupGetDTO.java
@@ -13,7 +13,7 @@ public class GroupGetDTO {
 
     private String votingType;
 
-    private GroupState state;
+    private GroupState groupState;
 
     public Long getId() {
         return id;
@@ -55,11 +55,10 @@ public class GroupGetDTO {
         this.votingType = votingType;
     }
 
-    public GroupState getState() {
-        return state;
+    public GroupState getGroupState() {
+        return groupState;
     }
-
-    public void setState(GroupState state) {
-        this.state = state;
+    public void setGroupState(GroupState groupState) {
+        this.groupState = groupState;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -195,6 +195,4 @@ public class GroupService {
 
         return groupRepository.save(group);
     }
-
-
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs23.service;
 
+import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
 import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
 import ch.uzh.ifi.hase.soprafs23.repository.GroupRepository;
@@ -26,16 +27,19 @@ public class GroupService {
 
     private final GroupRepository groupRepository;
     private final IngredientRepository ingredientRepository;
-
+    private final JoinRequestService joinRequestService;
+    private final InvitationService invitationService;
     private final UserService userService;
 
     @Autowired
-
     public GroupService(@Qualifier("groupRepository") GroupRepository groupRepository, IngredientRepository ingredientRepository,
-                        @Lazy @Qualifier("userService") UserService userService) {
+                        @Lazy @Qualifier("userService") UserService userService,
+                        @Lazy JoinRequestService joinRequestService, @Lazy InvitationService invitationService) {
         this.groupRepository = groupRepository;
         this.userService = userService;
         this.ingredientRepository = ingredientRepository;
+        this.joinRequestService = joinRequestService;
+        this.invitationService = invitationService;
     }
 
     public List<Group> getGroups() {
@@ -175,7 +179,22 @@ public class GroupService {
 
         return group;
     }
+    public boolean canUserJoinGroup(Long groupId) {
+        Group group = getGroupById(groupId);
+        return group.getGroupState() == GroupState.GROUPFORMING;
+    }
+    public Group changeGroupState(Long groupId, GroupState newState) {
+        Group group = getGroupById(groupId);
+        group.setGroupState(newState);
 
+        // If the new state is not GROUPFORMING, delete pending join requests and invitations
+        if (newState != GroupState.GROUPFORMING) {
+            joinRequestService.deleteJoinRequestsByGroupId(groupId);
+            invitationService.deleteInvitationsByGroupId(groupId);
+        }
+
+        return groupRepository.save(group);
+    }
 
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/InvitationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/InvitationService.java
@@ -35,7 +35,7 @@ public class InvitationService {
         }
 
         if (!groupService.canUserJoinGroup(groupId)) {
-            String errorMessage = String.format("Group %d is not in the GROUPFORMING state", groupId);
+            String errorMessage = String.format("You cannot create an invitation for Group %d because it is not in the GROUPFORMING state", groupId);
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, errorMessage);
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
@@ -38,6 +38,11 @@ public class JoinRequestService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, errorMessage);
         }
 
+        if (!groupService.canUserJoinGroup(groupId)) {
+            String errorMessage = String.format("Group %d is not in the GROUPFORMING state", groupId);
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, errorMessage);
+        }
+
         JoinRequest joinRequest = new JoinRequest();
         joinRequest.setGuestId(guestId);
         joinRequest.setGroupId(groupId);
@@ -83,7 +88,10 @@ public class JoinRequestService {
     public List<JoinRequest> getOpenJoinRequestsByGroupId(Long groupId) {
         return joinRequestRepository.findAllByGroupId(groupId);
     }
-
+    @Transactional
+    public void deleteJoinRequestsByGroupId(Long groupId) {
+        joinRequestRepository.deleteAllByGroupId(groupId);
+    }
 
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
@@ -51,7 +51,6 @@ public class JoinRequestService {
         return joinRequest;
     }
 
-
     public JoinRequest getJoinRequestByGuestIdAndGroupId(Long guestId, Long groupId) {
         Optional<JoinRequest> joinRequest = joinRequestRepository.findByGuestIdAndGroupId(guestId, groupId);
         if (joinRequest.isEmpty()) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
@@ -39,7 +39,7 @@ public class JoinRequestService {
         }
 
         if (!groupService.canUserJoinGroup(groupId)) {
-            String errorMessage = String.format("Group %d is not in the GROUPFORMING state", groupId);
+            String errorMessage = String.format("You cannot make a join request to Group %d because it is not in the GROUPFORMING state", groupId);
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, errorMessage);
         }
 
@@ -87,6 +87,7 @@ public class JoinRequestService {
     public List<JoinRequest> getOpenJoinRequestsByGroupId(Long groupId) {
         return joinRequestRepository.findAllByGroupId(groupId);
     }
+
     @Transactional
     public void deleteJoinRequestsByGroupId(Long groupId) {
         joinRequestRepository.deleteAllByGroupId(groupId);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
@@ -293,5 +293,4 @@ public class UserService {
         User user = getUserById(userId);
         return user.getGroupId() != null;
     }
-
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -9,7 +9,6 @@ import ch.uzh.ifi.hase.soprafs23.entity.JoinRequest;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
 import ch.uzh.ifi.hase.soprafs23.repository.JoinRequestRepository;
 import ch.uzh.ifi.hase.soprafs23.rest.dto.*;
-import ch.uzh.ifi.hase.soprafs23.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs23.service.GroupService;
 import ch.uzh.ifi.hase.soprafs23.service.InvitationService;
 import ch.uzh.ifi.hase.soprafs23.service.JoinRequestService;
@@ -40,8 +39,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.ArrayList;
 
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,7 +66,6 @@ public class GroupControllerTest {
     private InvitationService invitationService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-
 
     @Mock
     private JoinRequestRepository joinRequestRepository;


### PR DESCRIPTION
Since this is a branch of the Get Request branch I would recommend dealing with the PR of the GET Request first and then this one. So for the explanation of the code:

The endpoint PUT /groups/{groupId}/state with a new state in the request body will change the state of the group with ID groupId.

The endpoint GET /groups/{groupId}/state will retrieve the current state of the group with ID groupId.

The method canUserJoinGroup returns a boolean indicating whether a user can join the group with the specified ID based on its current state. A user can only join a group in the GROUPFORMING state.

The changeGroupState method that changes the state of the group with the specified ID and saves it to the database. If the new state is not GROUPFORMING, any pending join requests and invitations are deleted.

The InvitationService and JoinRequestService were added respectively to provide functionality for deleting invitations and join requests by their associated group ID. The methods utilize the deleteAllByGroupId method that was added to the repositories for Invitation and JoinRequest.

The deleteInvitationsByGroupId method in InvitationService takes a groupId parameter and uses the invitationRepository to delete all invitations associated with that group. Similarly, the deleteJoinRequestsByGroupId method in JoinRequestService takes a groupId parameter and uses the joinRequestRepository to delete all join requests associated with that group.

I added the deleteAllByGroupId method to the repositories to encapsulate the logic for deleting all Invitation and JoinRequest entities associated with a specific group.

Take your time with reviewing and testing with POSTMAN :)
