### PR TITLE
added logic to get ingredients call + tests

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -182,16 +182,22 @@ public class GroupService {
 
         Set<Ingredient> ingredients = group.getIngredients();
         Set<Long> ingredientToBeDeletedIds = new HashSet<>();
+        Set<Ingredient> ingredientsToBeRemoved = new HashSet<>();
 
         for (Ingredient ingredient : ingredients) {
             Set<User> ingredientUsers = ingredient.getUsersSet();
             if (ingredientUsers.contains(user)) {
                 if (ingredientUsers.size() == 1) {
                     ingredientToBeDeletedIds.add(ingredient.getId());
-                    group.removeIngredient(ingredient);
+                    ingredientsToBeRemoved.add(ingredient); // Don't remove it yet, just note it for removal
                 }
                 user.removeIngredient(ingredient);
             }
+        }
+
+        // Now it's safe to remove the ingredients from the group
+        for (Ingredient ingredient : ingredientsToBeRemoved) {
+            group.removeIngredient(ingredient);
         }
 
         for (Long id : ingredientToBeDeletedIds) {
@@ -201,6 +207,7 @@ public class GroupService {
             }
         }
     }
+
 
     public Group addGuestToGroup(Group group, Long guestId) {
         group.addGuestId(guestId);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
@@ -296,5 +296,11 @@ public class UserService {
         User user = getUserById(userId);
         return user.getAllergiesSet();
     }
+
+    public boolean userHasIngredients(Long userId) {
+        User user = getUserById(userId);
+        int ingredientSetSize = user.getIngredients().size();
+        return ingredientSetSize > 0;
+    }
     
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
 import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
 import ch.uzh.ifi.hase.soprafs23.constant.UserVotingStatus;
+import ch.uzh.ifi.hase.soprafs23.constant.VotingType;
 import ch.uzh.ifi.hase.soprafs23.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs23.repository.IngredientRepository;
 import ch.uzh.ifi.hase.soprafs23.rest.dto.UserPutDTO;
@@ -282,6 +283,7 @@ public class UserService {
             groupService.removeGuestFromGroup(group, userId);
         }
 
+        user.setVotingStatus(UserVotingStatus.NOT_VOTED);
         user.setGroupId(null);
         userRepository.save(user);
         userRepository.flush();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GroupControllerTest.java
@@ -754,6 +754,7 @@ public class GroupControllerTest {
 
         // mocks
         given(groupService.getAllMemberIdsOfGroup(group)).willReturn(memberIds);
+        given(userService.userHasIngredients(group.getHostId())).willReturn(true);
 
         // when
         MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/ingredients", group.getId())
@@ -786,6 +787,7 @@ public class GroupControllerTest {
 
         // mocks
         given(groupService.getAllMemberIdsOfGroup(group)).willReturn(memberIds);
+        given(userService.userHasIngredients(group.getHostId())).willReturn(true);
 
         // when
         MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/ingredients", group.getId())
@@ -796,6 +798,25 @@ public class GroupControllerTest {
         mockMvc.perform(getRequest)
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(3)));
+    }
+
+    @Test
+    public void testGetIngredientsOfGroupById_notYetEnteredIngredients() throws Exception {
+        List<Long> memberIds = new ArrayList<>();
+        memberIds.add(group.getHostId());
+
+        // mocks
+        given(groupService.getAllMemberIdsOfGroup(group)).willReturn(memberIds);
+        given(userService.userHasIngredients(group.getHostId())).willReturn(false);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/ingredients", group.getId())
+                                                    .contentType(MediaType.APPLICATION_JSON)
+                                                    .header("X-Token", user.getToken());
+
+        // then
+        mockMvc.perform(getRequest)
+            .andExpect(status().isAccepted());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/service/UserServiceTest.java
@@ -387,4 +387,16 @@ public class UserServiceTest {
         assertEquals(null, user.getGroupId());
     }
 
+    @Test
+    void userHasIngredients_test() {
+        assertTrue(userService.userHasIngredients(user.getId()));
+
+        User user_noIngredients = new User();
+        user_noIngredients.setId(5L);
+
+        when(userRepository.findById(user_noIngredients.getId())).thenReturn(Optional.of(user_noIngredients));
+
+        assertFalse(userService.userHasIngredients(user_noIngredients.getId()));
+    }
+
 }


### PR DESCRIPTION
implemented the changes to GET /groups/{groupId}/ingredients: 
- now checks that groupState is INGREDIENTVOTING -> if not it goes through all the members and checks if the have entered ingredients (throws 202 if not) and if all have entered ingredients sets the groupState to INGREDIENTVOTING
