### PR TITLE
Orestis logout

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
@@ -10,6 +10,7 @@ import ch.uzh.ifi.hase.soprafs23.rest.dto.IngredientPutDTO;
 import ch.uzh.ifi.hase.soprafs23.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs23.service.GroupService;
 import ch.uzh.ifi.hase.soprafs23.service.InvitationService;
+import ch.uzh.ifi.hase.soprafs23.service.JoinRequestService;
 import ch.uzh.ifi.hase.soprafs23.service.UserService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -38,10 +39,13 @@ public class UserController {
 
     private final InvitationService invitationService;
 
-    public UserController(UserService userService, GroupService groupService, InvitationService invitationService) {
+    private final JoinRequestService joinRequestService;
+
+    public UserController(UserService userService, GroupService groupService, InvitationService invitationService, JoinRequestService joinRequestService) {
         this.userService = userService;
         this.groupService = groupService;
         this.invitationService = invitationService;
+        this.joinRequestService = joinRequestService;
     }
 
     @GetMapping("/users")
@@ -126,8 +130,13 @@ public class UserController {
         if(!tokenId.equals(userId)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized.");
         }
+
+        // delete all join requests of the user
+        joinRequestService.deleteAllJoinRequests(userId);
+
         userService.logout(userId);
     }
+
 
     @PutMapping("/users/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT) //NO CONTENT IS 204

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs23.controller;
 
+import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
 import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Invitation;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
@@ -130,6 +131,12 @@ public class UserController {
         Long tokenId = userService.getUseridByToken(request.getHeader("X-Token"));
         if(!tokenId.equals(userId)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized.");
+        }
+
+        // Check if the user is in a group that is not in the GROUPFORMING state
+        Group currentGroup = groupService.getGroupByUserId(userId); // Replace this with the actual method
+        if(currentGroup != null && currentGroup.getGroupState() != GroupState.GROUPFORMING) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You cannot logout while your group is beyond the forming stage.");
         }
 
         // delete all join requests of the user

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/GroupRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/repository/GroupRepository.java
@@ -12,5 +12,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Optional<Group> findById(Long id);
 
+    Group findByHostId(Long hostId);
+
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -261,4 +261,15 @@ public class GroupService {
         return group;
     }
 
+    public Group getGroupByUserId(Long userId) {
+        User user = userService.getUserById(userId);
+        Long groupId = user.getGroupId();
+
+        if (groupId == null) {
+            return null;
+        } else {
+            return getGroupById(groupId);
+        }
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GroupService.java
@@ -250,4 +250,15 @@ public class GroupService {
         
         return allergies;
     }
+
+    public Group getGroupByHostId(Long hostId) {
+        Group group = this.groupRepository.findByHostId(hostId);
+
+        if (group == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Group with host id %s does not exist", hostId));
+        }
+
+        return group;
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/JoinRequestService.java
@@ -91,6 +91,13 @@ public class JoinRequestService {
         joinRequestRepository.deleteAllByGroupId(groupId);
     }
 
+    public void deleteAllJoinRequests(Long guestId) {
+        List<JoinRequest> joinRequests = joinRequestRepository.findAllByGuestId(guestId);
+        for (JoinRequest joinRequest : joinRequests) {
+            joinRequestRepository.delete(joinRequest);
+        }
+    }
+
 }
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
@@ -118,10 +118,14 @@ public class UserService {
 
     public void logout(Long id) {
         User user = getUserById(id);
+        if(isUserInGroup(id)){
+            leaveGroup(id);
+        }
         user.setStatus(UserStatus.OFFLINE);
         user = userRepository.save(user);
         userRepository.flush();
     }
+
 
     public void updateUser(Long id, UserPutDTO userPutDTO) {
         User user = getUserById(id);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/UserControllerTest.java
@@ -5,36 +5,41 @@ import ch.uzh.ifi.hase.soprafs23.constant.VotingType;
 import ch.uzh.ifi.hase.soprafs23.entity.Group;
 import ch.uzh.ifi.hase.soprafs23.entity.Invitation;
 import ch.uzh.ifi.hase.soprafs23.entity.User;
+import ch.uzh.ifi.hase.soprafs23.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs23.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs23.rest.dto.UserPutDTO;
 import ch.uzh.ifi.hase.soprafs23.rest.dto.IngredientPutDTO;
 import ch.uzh.ifi.hase.soprafs23.service.GroupService;
 import ch.uzh.ifi.hase.soprafs23.service.InvitationService;
+import ch.uzh.ifi.hase.soprafs23.service.JoinRequestService;
 import ch.uzh.ifi.hase.soprafs23.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Collections;
-import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import java.util.*;
 
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -58,6 +63,12 @@ public class UserControllerTest {
     @MockBean
     private InvitationService invitationService;
 
+    @MockBean
+    private JoinRequestService joinRequestService;
+
+    @Mock
+    private UserRepository userRepository;
+
     private User user;
 
     @BeforeEach
@@ -74,6 +85,13 @@ public class UserControllerTest {
         // mocks that are used in most tests
         given(userService.getUseridByToken(user.getToken())).willReturn(user.getId());
         given(userService.getUserById(user.getId())).willReturn(user);
+        given(userService.isUserInGroup(user.getId())).willReturn(true);
+
+    }
+
+    @BeforeEach
+    public void setup1() {
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
@@ -259,6 +277,30 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
                 .andExpect(result -> assertTrue(result.getResolvedException() instanceof ResponseStatusException));
+    }
+
+    @Test
+    public void logoutUser_shouldDeleteJoinRequestsAndLogoutUser() throws Exception {
+        // Arrange
+        String token = "testToken";
+        Long userId = 1L;
+        User user = new User();
+        user.setId(userId);
+        user.setToken(token);
+        user.setStatus(UserStatus.ONLINE);
+
+        given(userService.getUseridByToken(token)).willReturn(userId);
+        given(userService.getUserById(userId)).willReturn(user);
+
+        // Act
+        mockMvc.perform(post("/users/{userId}/logout", userId)
+                        .header("X-Token", token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        // Assert
+        verify(userService, times(1)).logout(userId);
+        verify(joinRequestService, times(1)).deleteAllJoinRequests(userId);
     }
 
     @Test


### PR DESCRIPTION
In this Updated logout PR there are several things added.

1) There is added check if the user is in a group or not. If he is not in a group he logs out normally, his join requests to join groups are deleted and his status is changed from ONLINE to OFFLINE. 

2) If the user is in a group then we have a couple of multiple checks. 
- 2a) If the user is a guest then he leaves the group and his status is changed from ONLINE to OFFLINE.
- 2b) If the user is the host of the group then the group is deleted and all of the invitations and join requests for the group are deleted. The user is logged out and his status is changed from ONLINE to OFFLINE.
- 2c) There is also an added check that IF the user is in a group (doesn't matter if he is HOST or GUEST) then he is only allowed to logout if the group is during the GROUPFORMING state.

Have fun doing some testing before merging :)