### PR TITLE
fixed bug with RECIPE/FINAL State in "/groups/{groupId}/result")

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
@@ -52,9 +52,6 @@ public class APIController {
     @ResponseStatus(HttpStatus.OK) // 200
     @ResponseBody
     public ResponseEntity<List<APIGetDTO>> getGroupRecipe(@PathVariable Long groupId, HttpServletRequest request) {
-        // change state
-        groupService.changeGroupState(groupId, GroupState.RECIPE);
-
         // 404 - group not found
         Group group = groupService.getGroupById(groupId);
 
@@ -120,7 +117,7 @@ public class APIController {
 
             apiGetDTOS.add(apiGetDTO);
         }
-        groupService.changeGroupState(groupId, GroupState.FINAL); //TODO: need to implement tests for this
+        groupService.changeGroupState(groupId, GroupState.FINAL); //TODO: need to implement more tests for this
         return new ResponseEntity<>(apiGetDTOS, HttpStatus.OK);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
@@ -64,10 +64,10 @@ public class APIController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "You are not authorized.");
         }
 
-        // 409 - groupState is not FINAL
+        // 409 - groupState is not RECIPE
         GroupState groupState = group.getGroupState();
-        if(!groupState.equals(GroupState.FINAL)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "The groupState is not FINAL"); // 409
+        if(!groupState.equals(GroupState.RECIPE)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "The groupState is not RECIPE"); // 409
         }
 
         List<RecipeInfo> recipeInfos = apiService.getRecipe(group);
@@ -116,10 +116,11 @@ public class APIController {
             apiGetDTO.setImage(recipe.getImage());
             apiGetDTO.setReadyInMinutes(recipe.getReadyInMinutes());
             apiGetDTO.setGroupId(groupId);
+            apiGetDTO.setIsRandomBasedOnIntolerances(recipeInfo.getIsRandomBasedOnIntolerances());
 
             apiGetDTOS.add(apiGetDTO);
         }
-
+        groupService.changeGroupState(groupId, GroupState.FINAL); //TODO: need to implement tests for this
         return new ResponseEntity<>(apiGetDTOS, HttpStatus.OK);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIGetDTO.java
@@ -12,6 +12,7 @@ public class APIGetDTO {
     private String instructions;
     private String image;
     private int readyInMinutes;
+    private boolean isRandomBasedOnIntolerances;
 
     // Getters and Setters
 
@@ -78,4 +79,13 @@ public class APIGetDTO {
     public void setReadyInMinutes(int readyInMinutes) {
         this.readyInMinutes = readyInMinutes;
     }
+
+    public boolean getIsRandomBasedOnIntolerances() {
+        return isRandomBasedOnIntolerances;
+    }
+
+    public void setIsRandomBasedOnIntolerances(boolean isRandomBasedOnIntolerances) {
+        this.isRandomBasedOnIntolerances = isRandomBasedOnIntolerances;
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
@@ -47,7 +47,6 @@ public class APIService {
     @Autowired
     private IngredientRepository ingredientRepository;
 
-    // TODO: give basic basic default recipe
 
     public Recipe getRandomRecipe(User host) { //TODO: use for Solo trip and for trouble shooting in case answer from Group is zero due to restrictions
         String intolerances = String.join(",", host.getAllergiesSet());
@@ -172,7 +171,7 @@ public class APIService {
             RecipeSearchResult searchResult = searchResponse.getBody();
 
             if (searchResult == null || searchResult.getResults().isEmpty()) {
-                throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Now we only send the allergies from all the guests in your group, but there is still no recipe found for it.");
+                throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Now we only send only the allergies from all the guests in your group, but there is still no recipe found for it.");
             }
             RecipeInfo resultRecipe = searchResult.getResults().get(0);
             resultRecipe.setIsRandomBasedOnIntolerances(false); // Setting new field to false
@@ -187,8 +186,6 @@ public class APIService {
             logger.error("Unexpected error occurred while fetching random recipe: " + e.getMessage(), e);
             throw new RuntimeException("Unexpected error occurred while fetching random recipe: " + e.getMessage());
         }
-
-
     }
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/RecipeInfo.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/RecipeInfo.java
@@ -18,6 +18,7 @@ public class RecipeInfo {
     private List<IngredientInfo> missedIngredients;
     private List<IngredientInfo> usedIngredients;
     private List<IngredientInfo> unusedIngredients;
+    private boolean isRandomBasedOnIntolerances;
 
 
     public RecipeInfo() {
@@ -111,5 +112,13 @@ public class RecipeInfo {
 
     public void setUnusedIngredients(List<IngredientInfo> unusedIngredients) {
         this.unusedIngredients = unusedIngredients;
+    }
+
+    public boolean getIsRandomBasedOnIntolerances() {
+        return isRandomBasedOnIntolerances;
+    }
+
+    public void setIsRandomBasedOnIntolerances(boolean isRandomBasedOnIntolerances) {
+        this.isRandomBasedOnIntolerances = isRandomBasedOnIntolerances;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
@@ -117,9 +117,8 @@ public class APIControllerTest {
 
     @Test
     public void getGroupRecipe_success_200() throws Exception {
-        testGroup.setGroupState(GroupState.RECIPE);
-
         when(groupService.getGroupById(1L)).thenReturn(testGroup);
+        testGroup.setGroupState(GroupState.RECIPE);
 
         MockHttpServletRequestBuilder getRequest = get("/groups/{groupId}/result", 1L)
                 .header("X-Token", "valid-token")
@@ -127,7 +126,7 @@ public class APIControllerTest {
 
         mockMvc.perform(getRequest).andExpect(status().is2xxSuccessful());
 
-        verify(groupService, times(1)).changeGroupState(1L, GroupState.RECIPE);
+        verify(groupService, times(1)).changeGroupState(1L, GroupState.FINAL);
     }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/APIControllerTest.java
@@ -63,8 +63,6 @@ public class APIControllerTest {
     @MockBean
     private FullIngredientRepository fullIngredientRepository;
 
-
-
     private Group testGroup;
     private User testUser;
     private Recipe testRecipe;
@@ -119,7 +117,7 @@ public class APIControllerTest {
 
     @Test
     public void getGroupRecipe_success_200() throws Exception {
-        testGroup.setGroupState(GroupState.FINAL);
+        testGroup.setGroupState(GroupState.RECIPE);
 
         when(groupService.getGroupById(1L)).thenReturn(testGroup);
 
@@ -145,7 +143,7 @@ public class APIControllerTest {
 
     @Test
     public void getGroupRecipe_noRecipesFound_404() throws Exception {
-        testGroup.setGroupState(GroupState.FINAL);
+        testGroup.setGroupState(GroupState.RECIPE);
         List<RecipeInfo> emptyRecipeList = new ArrayList<>();
         doReturn(emptyRecipeList).when(apiService).getRecipe(Mockito.any());
 
@@ -158,7 +156,7 @@ public class APIControllerTest {
 
     @Test
     public void getGroupRecipe_withDetailsFetched() throws Exception {
-        testGroup.setGroupState(GroupState.FINAL);
+        testGroup.setGroupState(GroupState.RECIPE);
         testRecipeDetails.setInstructions("Test instructions");
         testRecipeDetails.setImage("test-image.jpg");
         doReturn(testRecipeDetails).when(apiService).getRecipeDetails(Mockito.any());


### PR DESCRIPTION
I adjusted the isue with FINAL/RECIPE state. 
Also, now its possible to get a random recipe in case there is no result based on the ingredients and allergies. 
To show this differences I implemented a boolean IsRandomBasedOnIntolerances --> so frontend can check for this and display a respective text.

Also tested with Postman

<img width="944" alt="grafik" src="https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/f3c2b69b-8192-459c-b1a1-983d719ec39f">
<img width="819" alt="grafik" src="https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/da459230-31c6-4054-9f64-dcf3f2263fd0">
<img width="218" alt="grafik" src="https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/eacaa62c-aaef-4ddb-8833-9158fe32321f">

