### PR TITLE
Orestis ready

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/GroupController.java
@@ -376,9 +376,20 @@ public class GroupController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Only the Host can delete the Group"); // 401 - not authorized
         }
 
+        // Check if any member of the group is ready
+        List<Long> memberIds = groupService.getAllMemberIdsOfGroup(group);
+        boolean anyMemberReady = memberIds.stream()
+                .map(id -> userService.getUserById(id))
+                .anyMatch(User::isReady);
+
+        if (anyMemberReady) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Cannot delete the group while a member is ready"); // 409
+        }
+
         // Delete the group
         groupService.deleteGroup(groupId);
     }
+
 
     @PutMapping("/groups/{groupId}/leave")
     @ResponseStatus(HttpStatus.NO_CONTENT) // 204

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/entity/User.java
@@ -48,6 +48,10 @@ public class User implements Serializable {
     @Column(nullable = false)
     private UserVotingStatus votingStatus;
 
+    // Add a new field isReady
+    @Column(nullable = false)
+    private boolean isReady;
+
     @ManyToMany(cascade = CascadeType.ALL) // so all changes are applied to ingredients class which is associated
     @JoinTable(
             name = "USER_INGREDIENT",
@@ -177,5 +181,15 @@ public class User implements Serializable {
 
     public void setVotingStatus(UserVotingStatus votingStatus) {
         this.votingStatus = votingStatus;
+    }
+
+    // Add a getter for isReady
+    public boolean isReady() {
+        return isReady;
+    }
+
+    // Add a setter for isReady
+    public void setReady(boolean ready) {
+        this.isReady = ready;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/UserService.java
@@ -331,5 +331,4 @@ public class UserService {
         int ingredientSetSize = user.getIngredients().size();
         return ingredientSetSize > 0;
     }
-
 }


### PR DESCRIPTION
So in this ready state, each member of the group has the ability to show that they are ready in 3 different Group States. 

First of all in the GROUPFORMING state, when a user's status is changed from FALSE to TRUE then the host is not able to delete the group. When all the member's of the group have changed their status from FALSE to TRUE then the state of the group is changed from GROUPFORMING to INGREDIENTVOTING and the member's status changes from TRUE to FALSE so it can be used to the next ready check.

The next ready check happens when the state of the group is FINAL. There all the members of the group have the ability to check that they are READY so their state changes from FALSE to TRUE. When all of the members states are changed from FALSE to TRUE then the state of the group is changed from FINAL to RECIPE.

In the last ready check which happens in the RECIPE state, the same idea takes place but with an extra function. When all the members of the group have checked that they are ready and their status is changed from FALSE to TRUE then the group is deleted and their status changes to FALSE so they can repeat the same process if they want. Also an extra addition is that when a group is deleted its respective recipes are also deleted.

The mapping has also quite an amount of checks. 404 - NOT FOUND for user and group, 401 - UNAUTHORIZED for the user, and a check if you are a member of a group and a 409 - CONFLICT if the groupstate is not GROUPFROMING, FINAL, RECIPE.

Feel free to test and merge if it works so that frontend can work on it :) 