### PR TITLE
make sure everyone in group gets same recipe; refactored code

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIController.java
@@ -3,8 +3,6 @@ package ch.uzh.ifi.hase.soprafs23.SpooncularAPI;
 import ch.uzh.ifi.hase.soprafs23.entity.FullIngredient;
 import ch.uzh.ifi.hase.soprafs23.constant.GroupState;
 import ch.uzh.ifi.hase.soprafs23.entity.Group;
-import ch.uzh.ifi.hase.soprafs23.entity.Ingredient;
-import ch.uzh.ifi.hase.soprafs23.entity.User;
 import ch.uzh.ifi.hase.soprafs23.repository.FullIngredientRepository;
 import ch.uzh.ifi.hase.soprafs23.repository.IngredientRepository;
 import ch.uzh.ifi.hase.soprafs23.service.GroupService;
@@ -66,58 +64,78 @@ public class APIController {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "The groupState is not RECIPE"); // 409
         }
 
-        List<RecipeInfo> recipeInfos = apiService.getRecipe(group);
-
-        if (recipeInfos.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No recipes found");
-        }
-
         List<APIGetDTO> apiGetDTOS = new ArrayList<>();
 
-        for (RecipeInfo recipeInfo : recipeInfos) {
-            // Try to find recipe in db
-            Recipe recipe = recipeService.findByExternalRecipeIdAndGroupId(recipeInfo.getId(), groupId);
+        // Check if there is already a recipe associated with the group
+        List<Recipe> existingRecipes = recipeService.getRecipesByGroup(group);
 
-            // If recipe does not exist in db, create new one
-            if (recipe == null) {
-                recipe = new Recipe();
-                recipe.setExternalRecipeId(recipeInfo.getId());
+
+        // If recipes exist, convert them to APIGetDTO and return
+        if (!existingRecipes.isEmpty()) {
+            for (Recipe recipe : existingRecipes) {
+                APIGetDTO apiGetDTO = convertRecipeToAPIGetDTO(recipe);
+                apiGetDTOS.add(apiGetDTO);
+            }
+        } else {
+            // Else get new recipes from the Spoonacular API
+            List<RecipeInfo> recipeInfos = apiService.getRecipe(group);
+
+            if (recipeInfos.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No recipes found");
             }
 
-            recipe.setTitle(recipeInfo.getTitle());
-            recipe.setUsedIngredients(recipeInfo.getUsedIngredients().stream().map(IngredientInfo::getName).collect(Collectors.toList()));
-            recipe.setMissedIngredients(recipeInfo.getMissedIngredients().stream().map(IngredientInfo::getName).collect(Collectors.toList()));
-            recipe.setGroup(group);
+            for (RecipeInfo recipeInfo : recipeInfos) {
+                // Try to find recipe in db
+                Recipe recipe = recipeService.findByExternalRecipeIdAndGroupId(recipeInfo.getId(), groupId);
 
-            // Fetch additional details --> makes call to Spoonacular API and map response to RecipeDetailInfo object
-            RecipeDetailInfo detailInfo = apiService.getRecipeDetails(recipe.getExternalRecipeId());
-            if (detailInfo != null) {
-                recipe.setTitle(detailInfo.getTitle());
-                recipe.setReadyInMinutes(detailInfo.getReadyInMinutes());
-                recipe.setImage(detailInfo.getImage() != null ? detailInfo.getImage() : "Default image URL");
-                recipe.setInstructions(detailInfo.getInstructions() != null ? detailInfo.getInstructions() : "No instructions provided");
+                // If recipe does not exist in db, create new one
+                if (recipe == null) {
+                    recipe = new Recipe();
+                    recipe.setExternalRecipeId(recipeInfo.getId());
+                }
 
+                recipe.setTitle(recipeInfo.getTitle());
+                recipe.setUsedIngredients(recipeInfo.getUsedIngredients().stream().map(IngredientInfo::getName).collect(Collectors.toList()));
+                recipe.setMissedIngredients(recipeInfo.getMissedIngredients().stream().map(IngredientInfo::getName).collect(Collectors.toList()));
+                recipe.setIsRandomBasedOnIntolerances(recipeInfo.getIsRandomBasedOnIntolerances());
+                recipe.setGroup(group);
+
+                // Fetch additional details --> makes call to Spoonacular API and map response to RecipeDetailInfo object
+                RecipeDetailInfo detailInfo = apiService.getRecipeDetails(recipe.getExternalRecipeId());
+                if (detailInfo != null) {
+                    recipe.setTitle(detailInfo.getTitle());
+                    recipe.setReadyInMinutes(detailInfo.getReadyInMinutes());
+                    recipe.setImage(detailInfo.getImage() != null ? detailInfo.getImage() : "Default image URL");
+                    recipe.setInstructions(detailInfo.getInstructions() != null ? detailInfo.getInstructions() : "No instructions provided");
+
+                }
+                recipe.setGroup(group);
+
+                // Save/update the recipe in db
+                recipeService.save(recipe);
+
+                APIGetDTO apiGetDTO = convertRecipeToAPIGetDTO(recipe);
+                apiGetDTOS.add(apiGetDTO);
             }
-            recipe.setGroup(group);
-
-            // Save/update the recipe in db
-            recipeService.save(recipe);
-
-            APIGetDTO apiGetDTO = new APIGetDTO();
-            apiGetDTO.setId(recipe.getId());
-            apiGetDTO.setTitle(recipe.getTitle());
-            apiGetDTO.setUsedIngredients(recipe.getUsedIngredients());
-            apiGetDTO.setMissedIngredients(recipe.getMissedIngredients());
-            apiGetDTO.setInstructions(recipe.getInstructions());
-            apiGetDTO.setImage(recipe.getImage());
-            apiGetDTO.setReadyInMinutes(recipe.getReadyInMinutes());
-            apiGetDTO.setGroupId(groupId);
-            apiGetDTO.setIsRandomBasedOnIntolerances(recipeInfo.getIsRandomBasedOnIntolerances());
-
-            apiGetDTOS.add(apiGetDTO);
         }
         return new ResponseEntity<>(apiGetDTOS, HttpStatus.OK);
     }
+
+    //TODO: do we need our own DTOMapperAPI Class?
+    private APIGetDTO convertRecipeToAPIGetDTO(Recipe recipe) {
+        APIGetDTO apiGetDTO = new APIGetDTO();
+        apiGetDTO.setId(recipe.getId());
+        apiGetDTO.setTitle(recipe.getTitle());
+        apiGetDTO.setUsedIngredients(recipe.getUsedIngredients());
+        apiGetDTO.setMissedIngredients(recipe.getMissedIngredients());
+        apiGetDTO.setInstructions(recipe.getInstructions());
+        apiGetDTO.setImage(recipe.getImage());
+        apiGetDTO.setReadyInMinutes(recipe.getReadyInMinutes());
+        apiGetDTO.setGroupId(recipe.getGroup().getId());
+        apiGetDTO.setIsRandomBasedOnIntolerances(recipe.getIsRandomBasedOnIntolerances());
+        return apiGetDTO;
+    }
+
 
     @GetMapping("/ingredients")
     @ResponseStatus(HttpStatus.OK) // 200

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/APIService.java
@@ -11,9 +11,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import ch.uzh.ifi.hase.soprafs23.repository.FullIngredientRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import ch.uzh.ifi.hase.soprafs23.repository.IngredientRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -22,8 +20,6 @@ import org.springframework.web.client.RestTemplate;
 import ch.uzh.ifi.hase.soprafs23.repository.RecipeRepository;
 import org.springframework.web.server.ResponseStatusException;
 
-import javax.annotation.PostConstruct;
-import javax.persistence.criteria.CriteriaBuilder;
 import java.nio.charset.StandardCharsets;
 
 import java.util.*;
@@ -48,7 +44,7 @@ public class APIService {
     private IngredientRepository ingredientRepository;
 
 
-    public Recipe getRandomRecipe(User host) { //TODO: use for Solo trip and for trouble shooting in case answer from Group is zero due to restrictions
+    public Recipe getRandomRecipe(User host) { //TODO: use for Solo trip
         String intolerances = String.join(",", host.getAllergiesSet());
         String diet = host.getSpecialDiet();
         String cuisine = String.join(",", host.getFavoriteCuisineSet());
@@ -128,7 +124,7 @@ public class APIService {
             );
             RecipeSearchResult searchResult = searchResponse.getBody();
 
-            if (searchResult == null || searchResult.getResults().isEmpty()) { //TODO check with frontend if the can dispaly it like taht
+            if (searchResult == null || searchResult.getResults().isEmpty()) {
                 logger.info("No recipes found for the given ingredients. " +
                         "This is due to too high restrictions, e.g. your allergies matching all the given ingredients. " +
                         "We provide you now with a random recipe based only on your allergies, so you still have a cool meal to cook together!");
@@ -227,6 +223,8 @@ public class APIService {
             }
         }
     }
+
+
 
     public String getApiKey() {
         return apiKey;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/Recipe.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/SpooncularAPI/Recipe.java
@@ -35,7 +35,7 @@ public class Recipe implements Serializable {
     private List<String> usedIngredients;
 
     @ElementCollection
-    @CollectionTable(name = "MISSED_INGREDIENTS") //TODO: change this back?
+    @CollectionTable(name = "MISSED_INGREDIENTS")
     @Column(name = "INGREDIENT")
     private List<String> missedIngredients;
 
@@ -43,12 +43,17 @@ public class Recipe implements Serializable {
     @JoinColumn(name = "group_id")
     private Group group;
 
+
+    @Column(nullable = false)
+    private boolean isRandomBasedOnIntolerances;
+
     public Recipe() {}
 
     public Recipe(String title, List<String> usedIngredients, Group group) {
         this.title = title;
         this.usedIngredients = usedIngredients;
         this.group = group;
+        this.isRandomBasedOnIntolerances = false;
     }
 
     public long getId() {
@@ -118,6 +123,14 @@ public class Recipe implements Serializable {
             this.instructions = instructions;
         }
     }
+    public boolean getIsRandomBasedOnIntolerances() {
+        return this.isRandomBasedOnIntolerances;
+    }
+
+    public void setIsRandomBasedOnIntolerances(boolean isRandomBasedOnIntolerances) {
+        this.isRandomBasedOnIntolerances = isRandomBasedOnIntolerances;
+    }
+
 
     public Long getExternalRecipeId() {
         return externalRecipeId;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/controller/UserController.java
@@ -283,7 +283,6 @@ public class UserController {
         userService.addUserIngredients(userId, ingredientsPutDTO);
 
         // Check if all members of group have entered ingredients, change state if so
-        // Group group = groupService.getGroupById(user.getGroupId());
         List<Long> memberIds = groupService.getAllMemberIdsOfGroup(group);
         boolean changeState = true;
         for (Long memberId : memberIds) {
@@ -345,6 +344,6 @@ public class UserController {
             userService.setAllUsersNotReady(memberIds);
         }
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK); //TODO returns 200 or 204?
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/RecipeService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/RecipeService.java
@@ -32,4 +32,6 @@ public class RecipeService {
     public Recipe findByExternalRecipeIdAndGroupId(Long externalRecipeId, Long groupId) { //we need to check for both externalID AND GroupID
         return recipeRepository.findByExternalRecipeIdAndGroupId(externalRecipeId, groupId);
     }
+
+
 }


### PR DESCRIPTION
In this commit I refactored the code a bit to nicely be able to check if we already have a recipe from the group. Then this recipe will be send out to all members. Before this was missing, and as every group member send their own GET "/groups/{groupId}/result", they got diff recipes each. 

With the failing ingredient typing atm, its a pain to test. Also postman takes a while due to alle the states we now have :) I tested it with postman and attached the results here, so you can compare the outcome/token etc..
![grafik](https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/64121e43-af48-4fd8-9442-3a7bb8fa99f3)
![grafik](https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/0d991da1-a9ba-4b08-a7b0-ce48ad6218fb)
![grafik](https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/f7d42b70-dc57-443c-ba25-22635b9f054f)
![grafik](https://github.com/sopra-fs23-group-03/sopra-fs23-group-03-server/assets/91547040/3863ff4d-e0bf-4f3e-af7f-8eb305d0ac48)
